### PR TITLE
Добавила скрытие меню при включенном JS

### DIFF
--- a/source/js/script.js
+++ b/source/js/script.js
@@ -2,6 +2,8 @@ var navMain = document.querySelector('.main-nav');
 var navToggle = document.querySelector('.main-nav__toggle');
 
 navMain.classList.remove('main-nav--nojs');
+navMain.classList.remove('main-nav--opened');
+navMain.classList.add('main-nav--closed');
 
 navToggle.addEventListener('click', function() {
   if (navMain.classList.contains('main-nav--closed')) {


### PR DESCRIPTION
Непринятые базовые критерии Б30 и Б31 - некорректны! Крестик при выключенном JS скрывается! Я перепроверила этот пункт с моим личным наставником! 
Пишу об этом здесь, так как в чате интерфейса защиты вы не отвечаете.

В данном коммите я добавила скрытие мобильного меню при включенном JS.